### PR TITLE
feat: Deploy PiHole DNS server with GitOps

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,3 +7,4 @@ rules:
       - .github/workflows
       - taskfiles/infra/Taskfile.yml
       - apps/*/sealed-secret.yaml
+      - apps/*/manifests/sealed-secret.yaml

--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pihole
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    # Sealed secret manifest (deployed first via sync wave)
+    - repoURL: https://github.com/Mosher-Labs/homelab-gitops.git
+      targetRevision: main
+      path: apps/pihole/manifests
+    # Helm chart for PiHole
+    - repoURL: https://mojo2600.github.io/pihole-kubernetes/
+      chart: pihole
+      targetRevision: 2.34.0
+      helm:
+        valuesObject:
+        # Safe deployment - ClusterIP only, no network DNS exposure yet
+        serviceDns:
+          type: ClusterIP
+        serviceWeb:
+          type: ClusterIP
+
+        # Web UI ingress for management
+        ingress:
+          enabled: true
+          ingressClassName: traefik
+          hosts:
+            - pihole.mosher-labs.local
+          path: /
+          pathType: Prefix
+
+        # Admin password - from sealed secret
+        admin:
+          enabled: true
+          existingSecret: "pihole-password"
+          passwordKey: "password"
+
+        # Resource limits for homelab
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+
+        # Persistence for blocklists and config
+        persistentVolumeClaim:
+          enabled: true
+          accessModes:
+            - ReadWriteOnce
+          size: 1Gi
+
+        # DNS settings
+        DNS1: "1.1.1.1"  # Cloudflare upstream
+        DNS2: "1.0.0.1"  # Cloudflare upstream
+
+        # Enable DNSSEC
+        DNSSEC: "true"
+
+        # Timezone
+        timezone: "America/Denver"
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: pihole
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/pihole/manifests/sealed-secret.yaml
+++ b/apps/pihole/manifests/sealed-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: pihole-password
+  namespace: pihole
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData:
+    password: AgCkzI2AWYd1BLSw3sF2Q7REswTozvxcl1ZmmzCmUHmaYmiPI1ToG3oDSfGltbk7A9LRA4lLlWc8fQnCXGwMxK5utkfyYXuaw1ykAmkvlyr4AS4Fe/rB/wxpKPKLywtwfy3Y/mNT+OUm0OZvdOlEwVKcVrgO372dRGeKHCeYFumbFPOFl4Z8YwSmqhEJg/jRRWBkKyznNqhRf2/hXnxU0iuKpvh348u1c0Wp192xGlvDa3WFc3k3RRGjJ6AKZUMftGkrfxWzGUB4PMSMSiIqMdGfzXOZN6sNyF5iw9C3MHNlNayLUMJYORg6Pisp5WCISHmzikeEmSo+BCuws6A5iIiR11H4sr/MSL+/fr44jblBKquUvQJzHGcEZBgWEtYOT0K3Nb6m2rJ9hBQTD405ty0v1teJNNJSVzKiPTuR8rxcVW4Jn54r36A4+GI7RjEbRXbSs0hlt/rvCUJjfd59OtFb/a+FP76Ru3pvJcMfPUbmNRevYZwdXHYTIrIPbhOAmLL4VudK72Kfx7oJDpjZXxMBuCET1F/cLuUDSO2BqsrAAUFfxSDV121IoYIVB344weM+vU0tGJuJL4GlwPBEgdpzhhUR3SRQrBplQ5YzY/M7vQuKe/ysrQIdz4SRTmggg+RPspjrzImaf4Ly1TTAtNjSrR6jscNHZKCfvdgYp3i6bfSVxGskGT6CxIDCbg22XOnTZIarLTuicnEkf/Owc7NSmtIS
+  template:
+    metadata:
+      name: pihole-password
+      namespace: pihole


### PR DESCRIPTION
## Summary
- Deployed PiHole DNS server using ArgoCD and Helm (mojo2600/pihole v2.34.0)
- Sealed admin password using Sealed Secrets for GitOps-safe secret management
- Configured safe deployment with ClusterIP services (no network-wide DNS yet)

## Changes
- Added `apps/pihole/application.yaml` with PiHole ArgoCD Application
- Added `apps/pihole/sealed-secret.yaml` with encrypted admin password
- Web UI accessible at http://pihole.mosher-labs.local/admin/
- DNS service ready for testing at ClusterIP (10.43.250.139)

## Testing
- ✅ Pod deployed and running (1/1 Ready)
- ✅ Web UI accessible and login working
- ✅ DNS queries working (tested with `dig`)
- ✅ Ad-blocking verified (doubleclick.net blocked)

## Next Steps (After Merge)
- Test PiHole with individual devices before network-wide rollout
- Configure additional blocklists as needed
- Optionally expose DNS to network when ready

## Related
Part of Week 1 Kubernetes learning plan: GitOps Foundation (Tuesday tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)