### PR TITLE
feat: Add Homebridge for HomeKit smart home integration

### DIFF
--- a/apps/homebridge/application.yaml
+++ b/apps/homebridge/application.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: homebridge
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/Mosher-Labs/homelab-gitops.git
+    targetRevision: main
+    path: apps/homebridge/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: homebridge
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/homebridge/manifests/deployment.yaml
+++ b/apps/homebridge/manifests/deployment.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homebridge
+  namespace: homebridge
+  labels:
+    app: homebridge
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # Only one instance can use hostNetwork
+  selector:
+    matchLabels:
+      app: homebridge
+  template:
+    metadata:
+      labels:
+        app: homebridge
+    spec:
+      hostNetwork: true  # Required for mDNS/Bonjour and local device discovery
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: homebridge
+          image: homebridge/homebridge:latest
+          imagePullPolicy: Always
+          env:
+            - name: TZ
+              value: "America/Denver"
+            - name: HOMEBRIDGE_CONFIG_UI
+              value: "1"
+            - name: HOMEBRIDGE_CONFIG_UI_PORT
+              value: "8581"
+          ports:
+            - name: http
+              containerPort: 8581
+              protocol: TCP
+            - name: homekit
+              containerPort: 51826
+              protocol: TCP
+          volumeMounts:
+            - name: homebridge-data
+              mountPath: /homebridge
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8581
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8581
+            initialDelaySeconds: 30
+            periodSeconds: 10
+      volumes:
+        - name: homebridge-data
+          persistentVolumeClaim:
+            claimName: homebridge-data

--- a/apps/homebridge/manifests/ingress.yaml
+++ b/apps/homebridge/manifests/ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homebridge
+  namespace: homebridge
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: homebridge.mosher-labs.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homebridge
+                port:
+                  number: 8581

--- a/apps/homebridge/manifests/pvc.yaml
+++ b/apps/homebridge/manifests/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homebridge-data
+  namespace: homebridge
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/homebridge/manifests/service.yaml
+++ b/apps/homebridge/manifests/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homebridge
+  namespace: homebridge
+  labels:
+    app: homebridge
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8581
+      targetPort: 8581
+      protocol: TCP
+  selector:
+    app: homebridge


### PR DESCRIPTION
## Summary
Deploy Homebridge via ArgoCD to enable Apple HomeKit control of existing smart home devices.

## What's Included
- ✅ Homebridge deployment with hostNetwork for local device discovery
- ✅ Persistent storage for config and plugin data
- ✅ Web UI accessible at `http://homebridge.mosher-labs.local`
- ✅ Traefik ingress configuration
- ✅ ArgoCD Application for GitOps management

## Devices Supported
- **TP-Link Kasa** light switches (local WiFi discovery)
- **Ecobee** thermostat
- **Ring** cameras
- **MyQ** garage door opener

## Post-Merge Setup Required
After merging and deployment:
1. Access web UI at http://homebridge.mosher-labs.local
2. Install plugins via UI:
   - `homebridge-tplink-smarthome` (for Kasa switches)
   - `homebridge-ecobee`
   - `homebridge-ring`
   - `homebridge-myq`
3. Configure credentials for each service
4. Pair with iPhone/iPad Home app using QR code

## Architecture
\`\`\`
iPhone/iPad/Mac → HomeKit → Homebridge (K8s) → Plugins → Smart Devices
                                                 ├─ TP-Link (local)
                                                 ├─ Ecobee (API)
                                                 ├─ Ring (API)
                                                 └─ MyQ (API)
\`\`\`

## Testing Plan
- [ ] Verify pod starts successfully
- [ ] Access web UI via ingress
- [ ] Install TP-Link plugin and verify local device discovery
- [ ] Configure other plugins with credentials
- [ ] Pair with Home app on iPhone

🤖 Generated with [Claude Code](https://claude.com/claude-code)