### PR TITLE
feat: re-enable pihole-exporter with fallback DNS

### DIFF
--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -72,10 +72,10 @@ spec:
           monitoring:
             # Enable PodMonitor for Prometheus Operator
             podMonitor:
-              enabled: false
+              enabled: true
             # Enable pihole-exporter sidecar
             sidecar:
-              enabled: false
+              enabled: true
               port: 9617
               image:
                 repository: ekofr/pihole-exporter


### PR DESCRIPTION
## Summary

Re-enable pihole-exporter now that fallback DNS is configured on all nodes.

## Background

Previously disabled due to chicken-and-egg problem:
- PiHole pod couldn't pull exporter image
- Cluster DNS was down (PiHole was the only DNS)
- No way to resolve registry-1.docker.io

## Solution

With fallback DNS now configured (Mosher-Labs/ansible-node-setup#12):
- Primary DNS: 192.168.87.101 (PiHole)
- Fallback: 8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1
- Cluster can pull images even if PiHole is down

## Changes

- Enable `monitoring.podMonitor.enabled: true`
- Enable `monitoring.sidecar.enabled: true`
- Exporter image: ekofr/pihole-exporter:latest

## Test Plan

- [x] Pre-commit hooks passed
- [x] Merge and wait for ArgoCD sync
- [ ] Verify pihole pod restarts with 2 containers (pihole + exporter)
- [ ] Check PodMonitor is created
- [ ] Verify metrics endpoint: `curl localhost:9617/metrics`
- [ ] Confirm Prometheus is scraping
- [ ] Import Grafana dashboard (ID: 10176)

🤖 Generated with [Claude Code](https://claude.com/claude-code)