### PR TITLE
fix: resolve pihole DNS IP conflict with traefik

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Each app directory contains:
 ### Applications
 
 - **PiHole** (v2.34.0): DNS/ad-blocking - Web UI: `http://pihole.mosher-labs.local`,
-  DNS LoadBalancer IP: `192.168.87.100`, Upstream DNS: Cloudflare (1.1.1.1, 1.0.0.1)
+  DNS LoadBalancer IP: `192.168.87.101`, Upstream DNS: Cloudflare (1.1.1.1, 1.0.0.1)
 
 - **Homebridge** (latest): HomeKit bridge - Web UI:
   `http://homebridge.mosher-labs.local:8581`, Uses plain manifests (no good Helm
@@ -308,13 +308,13 @@ Example: Sealed secrets deploy before apps that consume them
 ### Local Network
 
 - **Range:** 192.168.3.0/24
-- **DNS:** PiHole at 192.168.87.100
+- **DNS:** PiHole at 192.168.87.101
 - **Ingress Domain:** *.mosher-labs.local (Traefik)
 
 ### MetalLB Pool
 
 - **Range:** 192.168.87.100-192.168.87.110
-- **Allocated:** 192.168.87.100: PiHole DNS service
+- **Allocated:** 192.168.87.100 (Traefik ingress), 192.168.87.101 (PiHole DNS)
 
 ### Port Notes
 

--- a/apps/pihole/README.md
+++ b/apps/pihole/README.md
@@ -10,7 +10,7 @@ on the network. Deployed via the mojo2600/pihole-kubernetes Helm chart.
 ## Access
 
 - **Web UI:** `http://pihole.mosher-labs.local`
-- **DNS Service:** `192.168.87.100` (MetalLB LoadBalancer)
+- **DNS Service:** `192.168.87.101` (MetalLB LoadBalancer)
 - **Admin Password:** Stored in sealed secret
 
 ## Configuration
@@ -106,7 +106,7 @@ kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:909
 ### DNS Not Working
 
 1. Verify LoadBalancer IP is assigned: `kubectl get svc -n pihole`
-1. Check DNS can be queried: `dig @192.168.87.100 google.com`
+1. Check DNS can be queried: `dig @192.168.87.101 google.com`
 1. Verify upstream DNS is reachable from pod
 1. Check PiHole logs for errors
 

--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -20,10 +20,11 @@ spec:
       helm:
         valuesObject:
           # DNS service exposed via LoadBalancer with dedicated IP from MetalLB
+          # Using .101 since Traefik ingress uses .100
           serviceDns:
             type: LoadBalancer
             port: 53
-            loadBalancerIP: "192.168.87.100"
+            loadBalancerIP: "192.168.87.101"
           serviceWeb:
             type: ClusterIP
 


### PR DESCRIPTION
## Summary

Fixes the PiHole DNS services stuck in "Progressing" state in ArgoCD.

## Problem

- PiHole DNS services (TCP/UDP) were requesting `192.168.87.100`
- Traefik ingress controller already has that IP allocated
- MetalLB error: "Failed to allocate IP for pihole/pihole-dns-tcp: can't
  change sharing key, address also in use by kube-system/traefik"
- Old manual `-lb` services existed with `192.168.87.101`

## Solution

- Changed PiHole DNS LoadBalancer IP to `192.168.87.101`
- Deleted old manual `pihole-dns-tcp-lb` and `pihole-dns-udp-lb` services
- Updated all documentation to reflect the new IP

## Changes

- `apps/pihole/application.yaml` - Changed `loadBalancerIP` to 192.168.87.101
- `claude.md` - Updated MetalLB allocations and PiHole DNS IP references
- `apps/pihole/README.md` - Updated DNS service IP in docs

## IP Allocations

- `192.168.87.100` - Traefik ingress controller
- `192.168.87.101` - PiHole DNS service

## Test Plan

- [ ] Verify PiHole DNS services get IP 192.168.87.101
- [ ] Check ArgoCD shows services as Healthy
- [ ] Test DNS resolution: `dig @192.168.87.101 google.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)