### PR TITLE
fix: enable MetalLB IP sharing for pihole DNS services

### DIFF
--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -25,6 +25,9 @@ spec:
             type: LoadBalancer
             port: 53
             loadBalancerIP: "192.168.87.101"
+            annotations:
+              # Allow TCP and UDP services to share the same IP
+              metallb.universe.tf/allow-shared-ip: pihole-dns
           serviceWeb:
             type: ClusterIP
 


### PR DESCRIPTION
## Summary

Fixes PiHole DNS TCP service stuck in "Progressing" state by enabling
MetalLB IP sharing between TCP and UDP services.

## Problem

- `pihole-dns-tcp` service stuck at `<pending>` status
- `pihole-dns-udp` successfully allocated `192.168.87.101`
- MetalLB error: "can't change sharing key for pihole/pihole-dns-tcp,
  address also in use by pihole/pihole-dns-udp"

## Root Cause

DNS requires **both TCP and UDP** on port 53 with the **same IP address**.
MetalLB was blocking this because the services didn't have the
`allow-shared-ip` annotation to permit IP sharing.

## Solution

Added MetalLB annotation to `serviceDns` configuration:

```yaml
serviceDns:
  annotations:
    metallb.universe.tf/allow-shared-ip: pihole-dns
```

This allows both TCP and UDP services to share `192.168.87.101`.

## Changes

- `apps/pihole/application.yaml` - Added `allow-shared-ip` annotation

## Test Plan

- [ ] Verify both DNS services get IP 192.168.87.101
- [ ] Check services show as Healthy in ArgoCD
- [ ] Test DNS over TCP: `dig +tcp @192.168.87.101 google.com`
- [ ] Test DNS over UDP: `dig @192.168.87.101 google.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)