### PR TITLE
fix(renovate): use RENOVATE_PRIVATE_KEY instead of file path

### DIFF
--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -42,8 +42,11 @@ spec:
                     secretKeyRef:
                       name: renovate-github-app
                       key: installation-id
-                - name: RENOVATE_PRIVATE_KEY_PATH
-                  value: "/secrets/private-key"
+                - name: RENOVATE_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-github-app
+                      key: private-key
                 # Git author
                 - name: RENOVATE_GIT_AUTHOR
                   value: "Renovate Bot <bot@renovateapp.com>"
@@ -60,9 +63,6 @@ spec:
               volumeMounts:
                 - name: config
                   mountPath: /config
-                - name: github-app-key
-                  mountPath: /secrets
-                  readOnly: true
               resources:
                 requests:
                   cpu: 100m
@@ -74,6 +74,3 @@ spec:
             - name: config
               configMap:
                 name: renovate-config
-            - name: github-app-key
-              secret:
-                secretName: renovate-github-app


### PR DESCRIPTION
## Issue

Renovate was failing with "You must configure a GitHub token" error because it wasn't recognizing the GitHub App credentials.

## Fix

Changed from  pointing to a mounted file to  environment variable directly from the secret.

## Changes

- Use  env var instead of 
- Remove volume mount for private key (no longer needed)
- Private key now passed directly as environment variable from secret

## Testing

After merging, the next CronJob run should authenticate successfully and start discovering repositories.

Cherry-picked from feat/self-hosted-renovate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)