### PR TITLE
fix(renovate): implement GitHub App token generation

### DIFF
--- a/infrastructure/renovate/manifests/configmap.yaml
+++ b/infrastructure/renovate/manifests/configmap.yaml
@@ -14,7 +14,7 @@ data:
         ":gitSignOff"
       ],
       "platform": "github",
-      "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+      "gitAuthor": "EikthyrnirBot <bot@renovateapp.com>",
       "autodiscover": true,
       "autodiscoverFilter": ["Mosher-Labs/*"],
       "timezone": "America/Denver",

--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -22,6 +22,29 @@ spec:
             app: renovate
         spec:
           restartPolicy: Never
+          initContainers:
+            - name: token-generator
+              image: alpine:3.19
+              command: ["/bin/sh", "/scripts/generate-token.sh"]
+              env:
+                - name: GITHUB_APP_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-github-app
+                      key: app-id
+                - name: GITHUB_INSTALLATION_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-github-app
+                      key: installation-id
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                - name: github-app-secret
+                  mountPath: /secrets
+                  readOnly: true
+                - name: token
+                  mountPath: /token
           containers:
             - name: renovate
               image: renovate/renovate:latest
@@ -31,25 +54,12 @@ spec:
                   value: "github"
                 - name: RENOVATE_ENDPOINT
                   value: "https://api.github.com"
-                # GitHub App authentication
-                - name: RENOVATE_GIT_APP_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: renovate-github-app
-                      key: app-id
-                - name: RENOVATE_GIT_APP_INSTALLATION_ID
-                  valueFrom:
-                    secretKeyRef:
-                      name: renovate-github-app
-                      key: installation-id
-                - name: RENOVATE_PRIVATE_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: renovate-github-app
-                      key: private-key
+                # GitHub token (generated from GitHub App)
+                - name: RENOVATE_TOKEN
+                  value: "file:/token/github-token"
                 # Git author
                 - name: RENOVATE_GIT_AUTHOR
-                  value: "Renovate Bot <bot@renovateapp.com>"
+                  value: "EikthyrnirBot <bot@renovateapp.com>"
                 # Log level and debugging
                 - name: LOG_LEVEL
                   value: "info"
@@ -63,6 +73,9 @@ spec:
               volumeMounts:
                 - name: config
                   mountPath: /config
+                - name: token
+                  mountPath: /token
+                  readOnly: true
               resources:
                 requests:
                   cpu: 100m
@@ -74,3 +87,12 @@ spec:
             - name: config
               configMap:
                 name: renovate-config
+            - name: scripts
+              configMap:
+                name: renovate-token-generator
+                defaultMode: 0755
+            - name: github-app-secret
+              secret:
+                secretName: renovate-github-app
+            - name: token
+              emptyDir: {}

--- a/infrastructure/renovate/manifests/token-generator-configmap.yaml
+++ b/infrastructure/renovate/manifests/token-generator-configmap.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-token-generator
+  namespace: renovate
+data:
+  generate-token.sh: |
+    #!/bin/sh
+    set -e
+
+    echo "Generating GitHub App installation token..."
+
+    # Read credentials from environment
+    APP_ID="${GITHUB_APP_ID}"
+    INSTALLATION_ID="${GITHUB_INSTALLATION_ID}"
+    PRIVATE_KEY_FILE="/secrets/private-key"
+
+    if [ -z "$APP_ID" ] || [ -z "$INSTALLATION_ID" ]; then
+      echo "ERROR: GITHUB_APP_ID or GITHUB_INSTALLATION_ID not set"
+      exit 1
+    fi
+
+    if [ ! -f "$PRIVATE_KEY_FILE" ]; then
+      echo "ERROR: Private key file not found at $PRIVATE_KEY_FILE"
+      exit 1
+    fi
+
+    # Generate JWT
+    now=$(date +%s)
+    iat=$((now - 60))
+    exp=$((now + 600))
+
+    header='{"alg":"RS256","typ":"JWT"}'
+    payload="{\"iat\":${iat},\"exp\":${exp},\"iss\":\"${APP_ID}\"}"
+
+    header_base64=$(echo -n "$header" | base64 | tr -d '=' | tr '/+' '_-' | \
+      tr -d '\n')
+    payload_base64=$(echo -n "$payload" | base64 | tr -d '=' | tr '/+' '_-' | \
+      tr -d '\n')
+
+    header_payload="${header_base64}.${payload_base64}"
+    signature=$(echo -n "${header_payload}" | openssl dgst -binary -sha256 \
+      -sign "$PRIVATE_KEY_FILE" | base64 | tr -d '=' | tr '/+' '_-' | \
+      tr -d '\n')
+
+    jwt="${header_payload}.${signature}"
+
+    echo "Generated JWT successfully"
+
+    # Exchange JWT for installation token
+    echo "Requesting installation token..."
+    api_url="https://api.github.com/app/installations"
+    token_url="${api_url}/${INSTALLATION_ID}/access_tokens"
+    response=$(wget -q -O - --header="Authorization: Bearer ${jwt}" \
+      --header="Accept: application/vnd.github+json" \
+      "${token_url}" \
+      --post-data='{}')
+
+    token=$(echo "$response" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
+
+    if [ -z "$token" ]; then
+      echo "ERROR: Failed to get installation token"
+      echo "Response: $response"
+      exit 1
+    fi
+
+    echo "Installation token generated successfully"
+    echo -n "$token" > /token/github-token
+
+    echo "Token saved to /token/github-token"


### PR DESCRIPTION
## Summary

Implements proper GitHub App authentication for self-hosted Renovate using token generation.

## Problem

Renovate does not support GitHub App authentication via environment variables like `RENOVATE_GIT_APP_ID`. Previous attempts failed because we were trying to pass App ID, Installation ID, and Private Key directly to Renovate, which it doesn't recognize.

## Solution

Add an init container that:
1. Generates a JWT from GitHub App credentials (App ID + Private Key)
2. Exchanges the JWT for a short-lived installation token (1 hour expiry) via GitHub API
3. Saves the token to a shared volume
4. Renovate reads the token as `RENOVATE_TOKEN`

## Changes

- **New**: `token-generator-configmap.yaml` - Contains shell script for token generation
- **Updated**: `cronjob.yaml` - Added init container and token volume mounts
- **Updated**: `configmap.yaml` - Changed gitAuthor to EikthyrnirBot

## Benefits

✅ No personal accounts (proper bus factor management)  
✅ Short-lived tokens (better security)  
✅ Enterprise best practice  
✅ Uses existing EikthyrnirBot GitHub App  
✅ Proper audit trail via GitHub App events

## Testing

After merge:
1. ArgoCD will sync the changes
2. Next CronJob run will use the token generation flow
3. Check logs for successful authentication
4. Verify Renovate creates Dependency Dashboard issues

## Related

Resolves authentication failures from PRs #18, #19, #20