### PR TITLE
fix(renovate): install openssl in token generator init container

### DIFF
--- a/infrastructure/renovate/manifests/token-generator-configmap.yaml
+++ b/infrastructure/renovate/manifests/token-generator-configmap.yaml
@@ -9,6 +9,9 @@ data:
     #!/bin/sh
     set -e
 
+    # Install required packages
+    apk add --no-cache openssl
+
     echo "Generating GitHub App installation token..."
 
     # Read credentials from environment


### PR DESCRIPTION
## Problem

The init container is failing to generate GitHub App installation tokens with:
```
/scripts/generate-token.sh: line 35: openssl: not found
wget: server returned error: HTTP/1.1 401 Unauthorized
```

## Root Cause

Alpine Linux base image doesn't include `openssl` by default, which is required for JWT signing.

## Solution

Add `apk add --no-cache openssl` at the start of the token generation script.

## Testing

After merge:
1. Wait for ArgoCD to sync
2. Next CronJob run should successfully generate installation token
3. Verify logs show:
   - "Generating GitHub App installation token..."
   - "Generated JWT successfully"
   - "Installation token generated successfully"
4. Renovate should authenticate and start processing repositories

## Related

- Fixes issue from PR #22
- Blocks Renovate from working until resolved