### PR TITLE
fix(renovate): improve token extraction from JSON response

### DIFF
--- a/infrastructure/renovate/manifests/token-generator-configmap.yaml
+++ b/infrastructure/renovate/manifests/token-generator-configmap.yaml
@@ -60,7 +60,9 @@ data:
       "${token_url}" \
       --post-data='{}')
 
-    token=$(echo "$response" | grep -o '"token":"[^"]*' | cut -d'"' -f4)
+    token=$(echo "$response" | \
+      grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*' | \
+      sed 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
     if [ -z "$token" ]; then
       echo "ERROR: Failed to get installation token"


### PR DESCRIPTION
## Problem

Init container successfully generates GitHub App installation token, but extraction from formatted JSON response fails.

The response has newlines:
```json
{
  "token": "ghs_xxx",
  ...
}
```

## Solution

- Use `[[:space:]]*` to handle whitespace/newlines  
- Use `sed` for robust extraction

## Related

Fixes token extraction from PR #23