### PR TITLE
fix: correct Renovate token extraction from JSON response

### DIFF
--- a/infrastructure/renovate/manifests/token-generator-configmap.yaml
+++ b/infrastructure/renovate/manifests/token-generator-configmap.yaml
@@ -61,8 +61,7 @@ data:
       --post-data='{}')
 
     token=$(echo "$response" | \
-      grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*' | \
-      sed 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+      sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
     if [ -z "$token" ]; then
       echo "ERROR: Failed to get installation token"


### PR DESCRIPTION
## Summary

Fixes the token extraction bug that was causing Renovate to fail authentication with `401 unauthorized` errors.

## Problem

The previous token extraction approach using `grep + sed` was not properly extracting just the token value from the GitHub API JSON response. Instead of extracting `ghs_...`, it was saving `"token": "ghs_...` to the token file, which caused Renovate to fail authentication.

**Evidence:**
```bash
$ cat /token/github-token
"token": "ghs_S5rOX0SXMONp0jew6kPMk4etIVaAWu3BZOYf
```

This resulted in:
```
WARN: github.com token 401 unauthorized
FATAL: Initialization error
       "errorMessage": "Authentication failure"
```

## Root Cause

The `grep -o` pattern `'"token"[[:space:]]*:[[:space:]]*"[^"]*'` matched the key-value pair but didn't include the closing quote, so when piped to `sed`, the substitution pattern `'s/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'` couldn't match (no closing quote in input) and outputted the original grep result.

## Solution

Replaced the two-command approach with a simpler **sed-only** solution:

```bash
# Before (broken)
token=$(echo "$response" | \
  grep -o '"token"[[:space:]]*:[[:space:]]*"[^"]*' | \
  sed 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')

# After (fixed)
token=$(echo "$response" | \
  sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
```

The `-n` flag suppresses automatic printing, and the `/p` flag prints only when substitution succeeds. This properly extracts just the token value between quotes.

## Testing

Local testing confirms the fix:
```bash
# Before: ["token": "ghs_testtoken123456789abcdef] (38 chars)
# After:  [ghs_testtoken123456789abcdef] (28 chars)
```

## Test Plan

- [ ] PR passes CI checks
- [ ] Merge to main
- [ ] ArgoCD syncs updated ConfigMap
- [ ] Manually trigger test job: `kubectl create job -n renovate renovate-verify-fix --from=cronjob/renovate`
- [ ] Verify token file contains clean token value
- [ ] Verify Renovate successfully authenticates and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)