### PR TITLE
fix: use direct token export instead of file: prefix for Renovate

### DIFF
--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -48,15 +48,17 @@ spec:
           containers:
             - name: renovate
               image: renovate/renovate:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  export RENOVATE_TOKEN=$(cat /token/github-token)
+                  exec renovate
               env:
                 # Platform
                 - name: RENOVATE_PLATFORM
                   value: "github"
                 - name: RENOVATE_ENDPOINT
                   value: "https://api.github.com"
-                # GitHub token (generated from GitHub App)
-                - name: RENOVATE_TOKEN
-                  value: "file:/token/github-token"
                 # Git author
                 - name: RENOVATE_GIT_AUTHOR
                   value: "EikthyrnirBot <bot@renovateapp.com>"


### PR DESCRIPTION
## Summary

Fixes the final authentication issue with Renovate by changing how the GitHub App installation token is passed to the Renovate container.

## Problem

After fixing the token extraction in PR #25, the token was being generated correctly:
- ✅ Token generation: SUCCESS
- ✅ Token format: `ghs_...` (40 chars, no JSON syntax)
- ✅ Direct API test: 200 OK, can access repositories
- ❌ Renovate authentication: 401 Unauthorized

The issue was that Renovate does NOT support the `file:` prefix format for `RENOVATE_TOKEN`:
```yaml
- name: RENOVATE_TOKEN
  value: "file:/token/github-token"  # ❌ Not supported by Renovate
```

## Solution

Changed the Renovate container to read the token file and export it directly before starting Renovate:

```yaml
containers:
  - name: renovate
    image: renovate/renovate:latest
    command: ["/bin/sh", "-c"]
    args:
      - |
        export RENOVATE_TOKEN=$(cat /token/github-token)
        exec renovate
    env:
      # ... other env vars (removed RENOVATE_TOKEN)
```

## Testing

Created test job `renovate-token-direct` with this approach and verified:
- ✅ Authentication successful
- ✅ Discovered 9 repositories in Mosher-Labs organization
- ✅ Scanned for dependency updates
- ✅ **Created pull requests!**

Example PR created by Renovate:
```
"prTitle": "chore(deps): update Mosher-Labs/.github action to v0.10.5"
```

## Related PRs

- PR #22: Initial GitHub App token generation implementation
- PR #23: Added openssl package to Alpine image
- PR #24: Fixed token extraction from formatted JSON
- PR #25: Improved sed-only token extraction (this discovered the file: prefix issue)
- **PR #26 (this PR)**: Final fix - direct token export instead of file: prefix

## Test Plan

- [x] PR passes CI checks
- [ ] Merge to main
- [ ] ArgoCD syncs updated CronJob
- [ ] Wait for next scheduled run (every 5 minutes)
- [ ] Verify Renovate successfully runs and creates/updates PRs
- [ ] Clean up test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)