### PR TITLE
fix(argocd): make topology spread constraints resilient to node failures

### DIFF
--- a/bootstrap/argocd/values.yaml
+++ b/bootstrap/argocd/values.yaml
@@ -64,11 +64,11 @@ argo-cd:
       requests:
         cpu: 100m
         memory: 128Mi
-    # HA: Topology spread - ensure one pod per node
+    # HA: Topology spread - prefer one pod per node (resilient to node failures)
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-server
@@ -93,11 +93,11 @@ argo-cd:
       requests:
         cpu: 250m
         memory: 256Mi
-    # HA: Topology spread - ensure one pod per node
+    # HA: Topology spread - prefer one pod per node (resilient to node failures)
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-repo-server
@@ -122,11 +122,11 @@ argo-cd:
       requests:
         cpu: 100m
         memory: 128Mi
-    # HA: Topology spread - ensure one pod per node
+    # HA: Topology spread - prefer one pod per node (resilient to node failures)
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-repo-server
@@ -151,11 +151,11 @@ argo-cd:
       requests:
         cpu: 50m
         memory: 64Mi
-    # HA: Topology spread
+    # HA: Topology spread - prefer one pod per node (resilient to node failures)
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
+        whenUnsatisfiable: ScheduleAnyway
         labelSelector:
           matchLabels:
             app.kubernetes.io/name: argocd-applicationset-controller


### PR DESCRIPTION
## Summary

- Changed topology spread constraints from hard (`DoNotSchedule`) to soft (`ScheduleAnyway`) for all ArgoCD components
- Fixes issue where pods remained Pending indefinitely when a node went down
- Scheduler will still prefer even distribution but allow scheduling when constraints can't be met

## Details

**Problem:**
When `battlestation-ubuntu` node went down, all ArgoCD pods with 3 replicas became stuck in Pending state. The topology constraints were set to `whenUnsatisfiable: DoNotSchedule`, which is a hard requirement. With `maxSkew: 1` and only 2 nodes available, the scheduler couldn't maintain even distribution (1 pod per node) and refused to schedule any pods.

**Solution:**
Changed `whenUnsatisfiable: ScheduleAnyway` for all ArgoCD components:
- `argocd-server`
- `argocd-controller` (application controller)
- `argocd-repo-server`
- `argocd-applicationset-controller`

**Behavior:**
- **Normal operation (3 nodes):** Pods distribute evenly, 1 per node (preferred)
- **Node failure (2 nodes):** Pods can still schedule on available nodes (2 pods on one node, 1 on another)
- **Recovery (3 nodes):** Scheduler will gradually re-balance to achieve even distribution

## Impact

- Improves cluster resilience to node failures
- ArgoCD services will remain available even when a node is down
- PDB (Pod Disruption Budget) still protects against deliberate disruptions
- No impact on normal operation when all nodes are healthy

## Test Plan

- Merge this PR
- ArgoCD will sync and apply changes
- Verify pods remain healthy with all 3 nodes up
- Future node failures should no longer block pod scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)