### PR TITLE
feat(monitoring): add Slack alerting for node failures and critical alerts

### DIFF
--- a/infrastructure/kube-prometheus-stack/application.yaml
+++ b/infrastructure/kube-prometheus-stack/application.yaml
@@ -13,16 +13,19 @@ spec:
   # Project: grouping/permission boundary
   project: default
 
-  # SOURCE: Where is the Helm chart?
-  source:
-    # Prometheus Community Helm repo
-    repoURL: https://prometheus-community.github.io/helm-charts
-    # Which chart to use
-    chart: kube-prometheus-stack
-    targetRevision: 79.7.1
-    # Helm values
-    helm:
-      valuesObject:
+  # SOURCES: Multiple sources for Helm chart + manifests
+  sources:
+    # Custom manifests (sealed secrets, PrometheusRules)
+    - repoURL: https://github.com/Mosher-Labs/homelab-gitops.git
+      targetRevision: main
+      path: infrastructure/kube-prometheus-stack/manifests
+
+    # Helm chart source
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      chart: kube-prometheus-stack
+      targetRevision: 79.7.1
+      helm:
+        valuesObject:
         # Prometheus Operator Configuration
         prometheusOperator:
           resources:
@@ -91,7 +94,45 @@ spec:
 
         # AlertManager Configuration
         alertmanager:
+          # AlertManager configuration via secret
+          config:
+            global:
+              resolve_timeout: 5m
+              slack_api_url_file: /etc/alertmanager/secrets/slack-webhook/url
+            route:
+              group_by: ['alertname', 'cluster', 'service']
+              group_wait: 10s
+              group_interval: 10s
+              repeat_interval: 12h
+              receiver: 'slack-notifications'
+              routes:
+                - match:
+                    alertname: Watchdog
+                  receiver: 'null'
+                - match:
+                    severity: critical
+                  receiver: 'slack-notifications'
+                  continue: true
+            receivers:
+              - name: 'null'
+              - name: 'slack-notifications'
+                slack_configs:
+                  - channel: '#homelab-alerts'
+                    title: 'Homelab Alert: {{ .GroupLabels.alertname }}'
+                    text: >-
+                      {{ range .Alerts }}
+                        *Alert:* {{ .Labels.alertname }}
+                        *Severity:* {{ .Labels.severity }}
+                        *Summary:* {{ .Annotations.summary }}
+                        *Description:* {{ .Annotations.description }}
+                        *Node:* {{ .Labels.node }}
+                      {{ end }}
+                    send_resolved: true
+
           alertmanagerSpec:
+            # Mount slack webhook secret
+            secrets:
+              - slack-webhook
             # Resource limits
             resources:
               limits:

--- a/infrastructure/kube-prometheus-stack/manifests/node-alerts.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/node-alerts.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-monitoring-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: node.rules
+      interval: 30s
+      rules:
+        # Node is NotReady for more than 1 minute
+        - alert: NodeNotReady
+          expr: kube_node_status_condition{condition="Ready",status="true"} == 0
+          for: 1m
+          labels:
+            severity: critical
+            component: node
+          annotations:
+            summary: "Node {{ $labels.node }} is not ready"
+            description: |
+              Node {{ $labels.node }} has been in NotReady state
+              for more than 1 minute. This may cause pod scheduling
+              failures and service disruptions.
+
+        # Node has memory pressure
+        - alert: NodeMemoryPressure
+          expr: |
+            kube_node_status_condition{condition="MemoryPressure",
+              status="true"} == 1
+          for: 5m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: "Node {{ $labels.node }} has memory pressure"
+            description: |
+              Node {{ $labels.node }} is experiencing memory pressure.
+              Pods may be evicted if memory usage continues to
+              increase.
+
+        # Node has disk pressure
+        - alert: NodeDiskPressure
+          expr: |
+            kube_node_status_condition{condition="DiskPressure",
+              status="true"} == 1
+          for: 5m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: "Node {{ $labels.node }} has disk pressure"
+            description: |
+              Node {{ $labels.node }} is experiencing disk pressure.
+              Pods may be evicted if disk usage continues to
+              increase.
+
+        # Node has PID pressure
+        - alert: NodePIDPressure
+          expr: |
+            kube_node_status_condition{condition="PIDPressure",
+              status="true"} == 1
+          for: 5m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: "Node {{ $labels.node }} has PID pressure"
+            description: |
+              Node {{ $labels.node }} is experiencing PID pressure.
+              Too many processes are running on this node.
+
+        # Node is unreachable
+        - alert: NodeUnreachable
+          expr: |
+            kube_node_spec_taint{effect="NoSchedule",
+              key="node.kubernetes.io/unreachable"} == 1
+          for: 1m
+          labels:
+            severity: critical
+            component: node
+          annotations:
+            summary: "Node {{ $labels.node }} is unreachable"
+            description: |
+              Node {{ $labels.node }} is marked as unreachable
+              by the cluster. Pods on this node cannot be managed
+              and may be terminated.
+
+        # High CPU usage on node
+        - alert: NodeHighCPUUsage
+          expr: |
+            (1 - avg by (instance)
+              (rate(node_cpu_seconds_total{mode="idle"}[5m])))
+              * 100 > 80
+          for: 10m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: "Node {{ $labels.instance }} has high CPU usage"
+            description: |
+              Node {{ $labels.instance }} has CPU usage above 80%
+              for more than 10 minutes.
+              Current usage: {{ $value | humanizePercentage }}
+
+        # High memory usage on node
+        - alert: NodeHighMemoryUsage
+          expr: |
+            (1 - (node_memory_MemAvailable_bytes /
+              node_memory_MemTotal_bytes)) * 100 > 80
+          for: 10m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: "Node {{ $labels.instance }} has high memory usage"
+            description: |
+              Node {{ $labels.instance }} has memory usage above 80%
+              for more than 10 minutes.
+              Current usage: {{ $value | humanizePercentage }}
+
+        # Filesystem usage high
+        - alert: NodeFilesystemAlmostFull
+          expr: |
+            (1 - (node_filesystem_avail_bytes{fstype!="tmpfs"} /
+              node_filesystem_size_bytes{fstype!="tmpfs"}))
+              * 100 > 85
+          for: 10m
+          labels:
+            severity: warning
+            component: node
+          annotations:
+            summary: >-
+              Filesystem {{ $labels.mountpoint }} on
+              {{ $labels.instance }} is almost full
+            description: |
+              Filesystem {{ $labels.mountpoint }} on node
+              {{ $labels.instance }} is
+              {{ $value | humanizePercentage }} full.
+              Please free up space or expand the volume.

--- a/infrastructure/kube-prometheus-stack/manifests/sealed-secret.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/sealed-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-webhook
+  namespace: monitoring
+spec:
+  encryptedData:
+    url: AgCM3MOJMQ2MFPTKWvwg3Ij1iJ75zB6Ize1vWRMs42jw1wRmsaJJUbX2gFA8CVj08smevGJ+QwjnYMmDSWPzl7QSMBWXm7BFLu9kfHI20FAc+fLdqUxRrmXPoFg8FUlIBgqbmBAvTpgfMEdXw/kOCU1WSrFcyW5kZbftJVVMknagyqyGlF+9F/Lqyq+Hu0pD2JOfHgPMx9wqjINRLkMCBUktXJ51RTZ7D5p3wLntYCpz+6kbv+4kEJaSIUQVfw/eHSEempf2l1oskoOl2ZIKUJn7FzzltIOmqLxgg27Pf1/UJm08ETv7sZbGe3D+6Z6iJ6u1t1+GsHz1z08Wmzsc4bsyMokXDdoFdUkXvUE4aEk2MLfGeaMdL0VQCp3l90QbS9IJRpKg7rRROk9kHpIUZ2Gho1gVzKtzp6D9VaZxkVTtHRJ7ojA4xZROJ4ZvLOywOtIEAN96ZUqCmsNj9PtU/dJqoprxB66wNO5SSJblEK/4fNhQcYNp002fVENe3fmKHzKGgHR4oHT/FRzulM5a/Clz+QaNvARWyWgty5Pj19HjSr8ZQr4aqSz7ZwYL5oooYJbnelSn3UTZC+8TZKPreYVTXi8P7sxn0v1Adu/7cRXVxFUG3jPRf1X3UbJIDqVJytu2Nyp1Y7UiZqISDs14UKiG9xUoR/A6kiYtYuszkV9vL/FyPsK6wnrGBvIIFvx4XSZcN3k++RXWMrm9lCHauDfSYWObDOOxTppP2GvP3iwf6jJrvUJyF7nWmNcckdFbcAa9HJgoxbWBqHokPHyiHzkHD6jELT/0SFJT2mgstg9kXJs=
+  template:
+    metadata:
+      name: slack-webhook
+      namespace: monitoring
+    type: Opaque


### PR DESCRIPTION
## Summary

- Configured AlertManager with Slack webhook for #homelab-alerts channel
- Added comprehensive PrometheusRules for node monitoring
- Sealed secret for Slack webhook URL

## Alerts Implemented

**Critical Alerts (immediate notification):**
- `NodeNotReady`: Node not ready for > 1 minute
- `NodeUnreachable`: Node marked as unreachable

**Warning Alerts:**
- `NodeMemoryPressure`: Node experiencing memory pressure
- `NodeDiskPressure`: Node experiencing disk pressure
- `NodePIDPressure`: Too many processes on node
- `NodeHighCPUUsage`: CPU usage > 80% for 10 minutes
- `NodeHighMemoryUsage`: Memory usage > 80% for 10 minutes
- `NodeFilesystemAlmostFull`: Filesystem > 85% full

## Configuration Details

- **Grouping**: Alerts grouped by alertname, cluster, service
- **Group Wait**: 10 seconds
- **Repeat Interval**: 12 hours
- **Receivers**: Slack notifications to #homelab-alerts
- **Watchdog**: Silenced (reduces noise)
- **Resolved Alerts**: Sent to Slack when issues clear

## Problem Solved

Addresses the issue where `battlestation-ubuntu` node failures went unnoticed for 18+ hours, causing DNS (PiHole) and other critical services to fail. With this alerting in place, you'll receive immediate Slack notifications when nodes go down.

## Test Plan

1. Merge and wait for ArgoCD sync
2. Check AlertManager UI to verify configuration
3. Verify current `battlestation-ubuntu` NotReady state triggers alert
4. Check #homelab-alerts channel for notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)