### PR TITLE
feat(pihole): convert to stateless HA setup with 3 replicas

### DIFF
--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -55,12 +55,13 @@ spec:
               cpu: 100m
               memory: 128Mi
 
-          # Persistence for blocklists and config
+          # HA: 3 replicas for high availability
+          replicaCount: 3
+
+          # Persistence disabled for stateless HA setup
+          # Configuration is managed via Helm values (GitOps)
           persistentVolumeClaim:
-            enabled: true
-            accessModes:
-              - ReadWriteOnce
-            size: 1Gi
+            enabled: false
 
           # DNS settings
           DNS1: "1.1.1.1"  # Cloudflare upstream
@@ -71,6 +72,32 @@ spec:
 
           # Timezone
           timezone: "America/Denver"
+
+          # HA: Topology spread constraints for even distribution
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: pihole
+                  release: pihole
+
+          # HA: Pod Disruption Budget - maintain at least 2 pods
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 2
+
+          # HA: Anti-affinity to prefer different nodes
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app: pihole
+                    topologyKey: kubernetes.io/hostname
 
           # Monitoring - Prometheus metrics
           # NOTE: Sidecar disabled due to circular dependency (can't pull


### PR DESCRIPTION
## Summary

Converts PiHole from single-replica with persistent storage to a stateless
3-replica high availability setup to survive node failures.

## Changes

**High Availability:**
- Increased replicas from 1 to 3
- Added topology spread constraints with `ScheduleAnyway`
- Added Pod Disruption Budget (minAvailable: 2)
- Added pod anti-affinity for node distribution

**Storage:**
- Disabled PersistentVolumeClaim (stateless)
- Configuration now managed via Helm values (GitOps)

## Benefits

- DNS survives single node failures
- No dependency on local-path storage
- True GitOps - configuration in Git
- Pods distribute evenly across all 3 nodes
- At least 2 pods always available during maintenance

## Trade-offs

- Query history/stats don't persist across pod restarts
- UI-based changes won't persist (must be added to Helm values)
- Custom blocklists should be managed via `adlists` in Helm values

## Problem Solved

This solves the critical issue where PiHole was unavailable when the
`battlestation-ubuntu` node went down because:
1. The PVC was pinned to that node (local-path storage)
2. Only 1 replica was running
3. DNS was completely unavailable during the outage

With this change, DNS will remain available even if any single node fails.

## Migration Notes

**Current PVC will be deleted** when this is deployed. If you have custom
blocklists or settings, they should be added to the Helm values before merging.

## Test Plan

1. Merge and wait for ArgoCD sync
2. Verify 3 PiHole pods running across different nodes
3. Test DNS resolution works
4. Simulate node failure by cordoning a node
5. Verify DNS still works with 2/3 pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)