### PR TITLE
feat(pihole): convert to stateless HA setup with 3 replicas

### DIFF
--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -55,12 +55,13 @@ spec:
               cpu: 100m
               memory: 128Mi
 
-          # Persistence for blocklists and config
+          # HA: 3 replicas for high availability
+          replicaCount: 3
+
+          # Persistence disabled for stateless HA setup
+          # Configuration is managed via Helm values (GitOps)
           persistentVolumeClaim:
-            enabled: true
-            accessModes:
-              - ReadWriteOnce
-            size: 1Gi
+            enabled: false
 
           # DNS settings
           DNS1: "1.1.1.1"  # Cloudflare upstream
@@ -71,6 +72,32 @@ spec:
 
           # Timezone
           timezone: "America/Denver"
+
+          # HA: Topology spread constraints for even distribution
+          topologySpreadConstraints:
+            - maxSkew: 1
+              topologyKey: kubernetes.io/hostname
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchLabels:
+                  app: pihole
+                  release: pihole
+
+          # HA: Pod Disruption Budget - maintain at least 2 pods
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 2
+
+          # HA: Anti-affinity to prefer different nodes
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        app: pihole
+                    topologyKey: kubernetes.io/hostname
 
           # Monitoring - Prometheus metrics
           # NOTE: Sidecar disabled due to circular dependency (can't pull

--- a/apps/pihole/manifests/pihole-exporter-deployment.yaml
+++ b/apps/pihole/manifests/pihole-exporter-deployment.yaml
@@ -9,7 +9,8 @@ metadata:
   labels:
     app: pihole-exporter
 spec:
-  replicas: 1
+  # HA: 3 replicas for high availability
+  replicas: 3
   selector:
     matchLabels:
       app: pihole-exporter
@@ -18,6 +19,24 @@ spec:
       labels:
         app: pihole-exporter
     spec:
+      # HA: Topology spread for even distribution across nodes
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: pihole-exporter
+      # HA: Prefer different nodes
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: pihole-exporter
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: pihole-exporter
           image: ekofr/pihole-exporter:latest


### PR DESCRIPTION
Changed PiHole from single-replica with persistent storage to stateless 3-replica high availability setup.

Changes:
- Increased replicas from 1 to 3 for HA
- Disabled PersistentVolumeClaim (stateless)
- Added topology spread constraints (ScheduleAnyway)
- Added Pod Disruption Budget (minAvailable: 2)
- Added pod anti-affinity for node distribution

Benefits:
- DNS survives single node failures
- No dependency on local-path storage
- Configuration managed via Git (true GitOps)
- Pods distribute across all 3 nodes

Trade-offs:
- Query history/stats don't persist across restarts
- UI-based changes need to be added to Git values
- Custom blocklists managed via Helm values

This solves the issue where PiHole was unavailable when battlestation-ubuntu node went down because the PVC was pinned to that node via local-path storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)