### PR TITLE
feat(renovate): add acebackapp org to autodiscover filter

### DIFF
--- a/infrastructure/renovate/README.md
+++ b/infrastructure/renovate/README.md
@@ -7,7 +7,8 @@ updates across the Mosher-Labs organization.
 
 - **Deployment:** CronJob (runs every 5 minutes)
 - **Authentication:** GitHub App
-- **Repositories:** Autodiscover all repos with `renovate.json` in Mosher-Labs
+- **Repositories:** Autodiscover repos with `renovate.json` in Mosher-Labs and
+  acebackapp orgs
 - **Monitoring:** Grafana dashboard for job history and status
 
 ## Quick Start
@@ -218,7 +219,7 @@ Renovate uses autodiscovery. Check:
 
 1. The GitHub App is installed on repositories
 1. Repositories have a `renovate.json` file
-1. The autodiscoverFilter matches: `"Mosher-Labs/*"`
+1. The autodiscoverFilter matches: `"Mosher-Labs/*"` or `"acebackapp/*"`
 
 View autodiscovery logs:
 

--- a/infrastructure/renovate/manifests/configmap.yaml
+++ b/infrastructure/renovate/manifests/configmap.yaml
@@ -16,7 +16,7 @@ data:
       "platform": "github",
       "gitAuthor": "EikthyrnirBot <bot@renovateapp.com>",
       "autodiscover": true,
-      "autodiscoverFilter": ["Mosher-Labs/*"],
+      "autodiscoverFilter": ["Mosher-Labs/*", "acebackapp/*"],
       "timezone": "America/Denver",
       "dependencyDashboard": true,
       "dependencyDashboardTitle": "🤖 Renovate Dependency Dashboard",


### PR DESCRIPTION
## Summary

- Add `acebackapp/*` to the Renovate autodiscoverFilter in the ConfigMap
- Update README to reflect the new organization coverage

This enables eikthyrnirbot to manage dependency updates for:
- `acebackapp/mobile` - React Native mobile app
- `acebackapp/api` - Supabase backend

## Changes

- `infrastructure/renovate/manifests/configmap.yaml`: Added `acebackapp/*` to autodiscoverFilter
- `infrastructure/renovate/README.md`: Updated documentation to reflect multi-org support

## Manual Trigger

After merging, you can manually trigger a Renovate run:

```bash
kubectl --kubeconfig ~/k3s.yaml create job -n renovate \
  renovate-manual-$(date +%s) --from=cronjob/renovate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)