### PR TITLE
fix(renovate): increase memory limit to prevent OOMKilled

### DIFF
--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -81,10 +81,10 @@ spec:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 512Mi
                 limits:
                   cpu: 1000m
-                  memory: 1Gi
+                  memory: 2Gi
           volumes:
             - name: config
               configMap:


### PR DESCRIPTION
## Summary

- Increase memory request from 256Mi to 512Mi
- Increase memory limit from 1Gi to 2Gi

## Problem

Renovate jobs were consistently getting OOMKilled when processing repositories
with many dependencies. For example, `tidr` has 63 dependencies across bundler,
docker-compose, dockerfile, github-actions, ruby-version, and terraform managers.

```
renovate-29417880            Failed    0/1           2d11h      2d11h
renovate-29419320            Failed    0/1           35h        35h
renovate-29420760            Failed    0/1           11h        11h
```

All pods showed `OOMKilled` status.

## Solution

Double the memory allocation to give Renovate enough headroom for larger repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)