### PR TITLE
fix(renovate): use file path for GitHub App private key

### DIFF
--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -37,11 +37,9 @@ spec:
                     secretKeyRef:
                       name: renovate-github-app
                       key: app-id
-                - name: RENOVATE_GITHUB_APP_KEY
-                  valueFrom:
-                    secretKeyRef:
-                      name: renovate-github-app
-                      key: private-key
+                # Use file path for private key to preserve newlines
+                - name: RENOVATE_GITHUB_APP_KEY_PATH
+                  value: "/secrets/private-key"
                 # Git author
                 - name: RENOVATE_GIT_AUTHOR
                   value: "EikthyrnirBot <bot@renovateapp.com>"
@@ -58,6 +56,9 @@ spec:
               volumeMounts:
                 - name: config
                   mountPath: /config
+                - name: github-app-secret
+                  mountPath: /secrets
+                  readOnly: true
               resources:
                 requests:
                   cpu: 100m
@@ -69,3 +70,6 @@ spec:
             - name: config
               configMap:
                 name: renovate-config
+            - name: github-app-secret
+              secret:
+                secretName: renovate-github-app


### PR DESCRIPTION
## Summary

Fix GitHub App authentication by mounting the private key as a file instead of
passing it as an environment variable.

## Problem

The private key's newlines were being lost when passed via
`RENOVATE_GITHUB_APP_KEY` env var, causing:
```
FATAL: Initialization error
       "errorMessage": "You must configure a GitHub token"
```

## Solution

- Mount the `renovate-github-app` secret as a volume at `/secrets`
- Use `RENOVATE_GITHUB_APP_KEY_PATH=/secrets/private-key` instead
- This preserves the PEM file's newline characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)