### PR TITLE
fix(renovate): read private key from file at runtime

### DIFF
--- a/infrastructure/renovate/manifests/cronjob.yaml
+++ b/infrastructure/renovate/manifests/cronjob.yaml
@@ -25,6 +25,11 @@ spec:
           containers:
             - name: renovate
               image: renovate/renovate:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  export RENOVATE_GITHUB_APP_KEY="$(cat /secrets/private-key)"
+                  exec renovate
               env:
                 # Platform
                 - name: RENOVATE_PLATFORM
@@ -37,9 +42,6 @@ spec:
                     secretKeyRef:
                       name: renovate-github-app
                       key: app-id
-                # Use file path for private key to preserve newlines
-                - name: RENOVATE_GITHUB_APP_KEY_PATH
-                  value: "/secrets/private-key"
                 # Git author
                 - name: RENOVATE_GIT_AUTHOR
                   value: "EikthyrnirBot <bot@renovateapp.com>"


### PR DESCRIPTION
## Summary

Read the GitHub App private key from the mounted secret file at container
startup, preserving newlines properly.

## Problem

`RENOVATE_GITHUB_APP_KEY_PATH` is not a valid Renovate environment variable.
The previous fix didn't work because Renovate doesn't recognize that option.

## Solution

Use a shell command to:
1. Read the private key from `/secrets/private-key`
2. Export it as `RENOVATE_GITHUB_APP_KEY`
3. Then exec renovate

```yaml
command: ["/bin/sh", "-c"]
args:
  - |
    export RENOVATE_GITHUB_APP_KEY="$(cat /secrets/private-key)"
    exec renovate
```

This properly preserves the PEM file's newline characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)