### PR TITLE
fix: increase memory for benniemosher-dev renovate cronjob

### DIFF
--- a/infrastructure/renovate/manifests/cronjob-benniemosher-dev.yaml
+++ b/infrastructure/renovate/manifests/cronjob-benniemosher-dev.yaml
@@ -15,6 +15,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         metadata:
           labels:
@@ -83,7 +84,7 @@ spec:
                   memory: 512Mi
                 limits:
                   cpu: 1000m
-                  memory: 2Gi
+                  memory: 3Gi
           volumes:
             - name: config
               configMap:


### PR DESCRIPTION
## Summary
- Add missing `backoffLimit: 2` to prevent excessive retries
- Increase memory limit from 2Gi to 3Gi (OOMKilled 3x during testing with Terraform repos)

## Test plan
- [x] Tested other cronjobs (mosher-labs, discrapp, benniemosher) - all completed successfully with 2Gi
- [ ] After merge, manually trigger benniemosher-dev job to verify 3Gi is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)