### PR TITLE
feat: add comprehensive Prometheus alerting rules

### DIFF
--- a/infrastructure/kube-prometheus-stack/manifests/argocd-alerts.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/argocd-alerts.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: argocd-monitoring-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: argocd.rules
+      interval: 30s
+      rules:
+        # ArgoCD application out of sync
+        - alert: ArgoCDAppOutOfSync
+          expr: |
+            argocd_app_info{sync_status!="Synced"} == 1
+          for: 30m
+          labels:
+            severity: warning
+            component: argocd
+          annotations:
+            summary: "ArgoCD app {{ $labels.name }} out of sync"
+            description: |
+              ArgoCD application {{ $labels.name }} has been out of sync
+              for more than 30 minutes. Sync status: {{ $labels.sync_status }}
+
+        # ArgoCD application unhealthy
+        - alert: ArgoCDAppUnhealthy
+          expr: |
+            argocd_app_info{health_status!="Healthy",
+              health_status!="Progressing"} == 1
+          for: 15m
+          labels:
+            severity: warning
+            component: argocd
+          annotations:
+            summary: "ArgoCD app {{ $labels.name }} unhealthy"
+            description: |
+              ArgoCD application {{ $labels.name }} is unhealthy.
+              Health status: {{ $labels.health_status }}
+
+        # ArgoCD application sync failed
+        - alert: ArgoCDAppSyncFailed
+          expr: |
+            argocd_app_info{sync_status="Unknown"} == 1
+          for: 5m
+          labels:
+            severity: critical
+            component: argocd
+          annotations:
+            summary: "ArgoCD app {{ $labels.name }} sync unknown"
+            description: |
+              ArgoCD application {{ $labels.name }} has unknown sync status.
+              This may indicate a sync failure or configuration issue.
+
+        # ArgoCD server not ready
+        - alert: ArgoCDServerNotReady
+          expr: |
+            kube_deployment_status_replicas_available{
+              deployment="argocd-server",namespace="argocd"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: argocd
+          annotations:
+            summary: "ArgoCD server not available"
+            description: |
+              ArgoCD server has no available replicas.
+              GitOps deployments will not function.
+
+        # ArgoCD repo server not ready
+        - alert: ArgoCDRepoServerNotReady
+          expr: |
+            kube_deployment_status_replicas_available{
+              deployment="argocd-repo-server",namespace="argocd"} == 0
+          for: 5m
+          labels:
+            severity: critical
+            component: argocd
+          annotations:
+            summary: "ArgoCD repo server not available"
+            description: |
+              ArgoCD repo server has no available replicas.
+              Application syncs will fail.

--- a/infrastructure/kube-prometheus-stack/manifests/deployment-alerts.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/deployment-alerts.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: deployment-monitoring-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: deployment.rules
+      interval: 30s
+      rules:
+        # Deployment has no available replicas
+        - alert: DeploymentNoAvailableReplicas
+          expr: |
+            kube_deployment_status_replicas_available == 0
+            and kube_deployment_spec_replicas > 0
+          for: 5m
+          labels:
+            severity: critical
+            component: deployment
+          annotations:
+            summary: "Deployment {{ $labels.deployment }} has no replicas"
+            description: |
+              Deployment {{ $labels.namespace }}/{{ $labels.deployment }}
+              has no available replicas for more than 5 minutes.
+              Service may be completely unavailable.
+
+        # Deployment replicas mismatch
+        - alert: DeploymentReplicasMismatch
+          expr: |
+            kube_deployment_spec_replicas !=
+            kube_deployment_status_replicas_available
+          for: 15m
+          labels:
+            severity: warning
+            component: deployment
+          annotations:
+            summary: "Deployment {{ $labels.deployment }} replica mismatch"
+            description: |
+              Deployment {{ $labels.namespace }}/{{ $labels.deployment }}
+              has {{ $value }} available replicas, but
+              {{ $labels.spec_replicas }} were requested.
+
+        # StatefulSet replicas mismatch
+        - alert: StatefulSetReplicasMismatch
+          expr: |
+            kube_statefulset_status_replicas_ready !=
+            kube_statefulset_status_replicas
+          for: 15m
+          labels:
+            severity: warning
+            component: statefulset
+          annotations:
+            summary: "StatefulSet {{ $labels.statefulset }} replica mismatch"
+            description: |
+              StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }}
+              does not have all replicas ready.
+
+        # DaemonSet not scheduled on all nodes
+        - alert: DaemonSetNotScheduled
+          expr: |
+            kube_daemonset_status_desired_number_scheduled -
+            kube_daemonset_status_current_number_scheduled > 0
+          for: 10m
+          labels:
+            severity: warning
+            component: daemonset
+          annotations:
+            summary: "DaemonSet {{ $labels.daemonset }} not fully scheduled"
+            description: |
+              DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+              is not scheduled on all desired nodes.
+
+        # DaemonSet pods not ready
+        - alert: DaemonSetPodsNotReady
+          expr: |
+            kube_daemonset_status_number_ready /
+            kube_daemonset_status_desired_number_scheduled < 1
+          for: 10m
+          labels:
+            severity: warning
+            component: daemonset
+          annotations:
+            summary: "DaemonSet {{ $labels.daemonset }} pods not ready"
+            description: |
+              DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+              does not have all pods in ready state.
+
+        # HPA at max replicas
+        - alert: HPAAtMaxReplicas
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas ==
+            kube_horizontalpodautoscaler_spec_max_replicas
+          for: 30m
+          labels:
+            severity: warning
+            component: hpa
+          annotations:
+            summary: "HPA {{ $labels.horizontalpodautoscaler }} at max"
+            description: |
+              HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }}
+              has been at max replicas for 30 minutes.
+              Consider increasing max replicas if load continues.

--- a/infrastructure/kube-prometheus-stack/manifests/pod-alerts.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/pod-alerts.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pod-monitoring-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: pod.rules
+      interval: 30s
+      rules:
+        # Container was OOMKilled
+        - alert: ContainerOOMKilled
+          expr: |
+            kube_pod_container_status_last_terminated_reason{
+              reason="OOMKilled"} > 0
+          for: 0m
+          labels:
+            severity: warning
+            component: container
+          annotations:
+            summary: "Container {{ $labels.container }} OOMKilled"
+            description: |
+              Container {{ $labels.container }} in pod
+              {{ $labels.namespace }}/{{ $labels.pod }} was OOMKilled.
+              Consider increasing memory limits.
+
+        # Pod restarting frequently
+        - alert: PodRestartingFrequently
+          expr: |
+            increase(kube_pod_container_status_restarts_total[1h]) > 3
+          for: 5m
+          labels:
+            severity: warning
+            component: pod
+          annotations:
+            summary: "Pod {{ $labels.pod }} restarting frequently"
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has
+              restarted {{ $value | humanize }} times in the last hour.
+
+        # Pod in CrashLoopBackOff
+        - alert: PodCrashLoopBackOff
+          expr: |
+            kube_pod_container_status_waiting_reason{
+              reason="CrashLoopBackOff"} == 1
+          for: 5m
+          labels:
+            severity: critical
+            component: pod
+          annotations:
+            summary: "Pod {{ $labels.pod }} in CrashLoopBackOff"
+            description: |
+              Container {{ $labels.container }} in pod
+              {{ $labels.namespace }}/{{ $labels.pod }} is in
+              CrashLoopBackOff state for more than 5 minutes.
+
+        # Pod pending for too long
+        - alert: PodPendingTooLong
+          expr: |
+            kube_pod_status_phase{phase="Pending"} == 1
+          for: 15m
+          labels:
+            severity: warning
+            component: pod
+          annotations:
+            summary: "Pod {{ $labels.pod }} pending too long"
+            description: |
+              Pod {{ $labels.namespace }}/{{ $labels.pod }} has been
+              in Pending state for more than 15 minutes.
+              Check node resources or scheduling constraints.
+
+        # Job failed
+        - alert: KubernetesJobFailed
+          expr: kube_job_status_failed > 0
+          for: 1m
+          labels:
+            severity: warning
+            component: job
+          annotations:
+            summary: "Job {{ $labels.job_name }} failed"
+            description: |
+              Job {{ $labels.namespace }}/{{ $labels.job_name }} failed.
+              Check job logs for details.
+
+        # Container CPU throttling
+        - alert: ContainerCPUThrottlingHigh
+          expr: |
+            sum by (container, pod, namespace) (
+              increase(
+                container_cpu_cfs_throttled_periods_total[5m]
+              )
+            ) /
+            sum by (container, pod, namespace) (
+              increase(
+                container_cpu_cfs_periods_total[5m]
+              )
+            ) > 0.25
+          for: 15m
+          labels:
+            severity: warning
+            component: container
+          annotations:
+            summary: "Container CPU throttling high"
+            description: |
+              Container {{ $labels.container }} in pod
+              {{ $labels.namespace }}/{{ $labels.pod }} is being
+              throttled {{ $value | humanizePercentage }} of the time.
+              Consider increasing CPU limits.

--- a/infrastructure/kube-prometheus-stack/manifests/storage-alerts.yaml
+++ b/infrastructure/kube-prometheus-stack/manifests/storage-alerts.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: storage-monitoring-alerts
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack
+    role: alert-rules
+spec:
+  groups:
+    - name: storage.rules
+      interval: 30s
+      rules:
+        # PVC almost full
+        - alert: PersistentVolumeAlmostFull
+          expr: |
+            kubelet_volume_stats_used_bytes /
+            kubelet_volume_stats_capacity_bytes * 100 > 85
+          for: 5m
+          labels:
+            severity: warning
+            component: storage
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} almost full"
+            description: |
+              PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}
+              is {{ $value | humanize }}% full.
+              Consider expanding the volume or cleaning up data.
+
+        # PVC critically full
+        - alert: PersistentVolumeCriticallyFull
+          expr: |
+            kubelet_volume_stats_used_bytes /
+            kubelet_volume_stats_capacity_bytes * 100 > 95
+          for: 1m
+          labels:
+            severity: critical
+            component: storage
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} critically full"
+            description: |
+              PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}
+              is {{ $value | humanize }}% full.
+              Immediate action required to prevent data loss.
+
+        # PV in failed state
+        - alert: PersistentVolumeFailed
+          expr: kube_persistentvolume_status_phase{phase="Failed"} == 1
+          for: 1m
+          labels:
+            severity: critical
+            component: storage
+          annotations:
+            summary: "PersistentVolume {{ $labels.persistentvolume }} failed"
+            description: |
+              PersistentVolume {{ $labels.persistentvolume }} is in
+              Failed state. Data may be at risk.
+
+        # PVC pending for too long
+        - alert: PersistentVolumeClaimPending
+          expr: kube_persistentvolumeclaim_status_phase{phase="Pending"} == 1
+          for: 15m
+          labels:
+            severity: warning
+            component: storage
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} pending"
+            description: |
+              PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}
+              has been pending for more than 15 minutes.
+              Check storage provisioner and available capacity.
+
+        # PVC inodes running low
+        - alert: PersistentVolumeInodesLow
+          expr: |
+            kubelet_volume_stats_inodes_used /
+            kubelet_volume_stats_inodes * 100 > 85
+          for: 5m
+          labels:
+            severity: warning
+            component: storage
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} inodes low"
+            description: |
+              PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }}
+              has used {{ $value | humanize }}% of available inodes.
+              Too many small files may be causing this.


### PR DESCRIPTION
## Summary
Add new PrometheusRule manifests for better cluster observability:

### Pod Alerts (`pod-alerts.yaml`)
- **ContainerOOMKilled** - Immediate alert when container is OOMKilled
- **PodRestartingFrequently** - >3 restarts in 1 hour
- **PodCrashLoopBackOff** - Pod stuck in CrashLoopBackOff for 5m
- **PodPendingTooLong** - Pod pending for 15m+
- **KubernetesJobFailed** - Job failure notification
- **ContainerCPUThrottlingHigh** - >25% CPU throttling for 15m

### Storage Alerts (`storage-alerts.yaml`)
- **PersistentVolumeAlmostFull** - PVC >85% full
- **PersistentVolumeCriticallyFull** - PVC >95% full (critical)
- **PersistentVolumeFailed** - PV in failed state
- **PersistentVolumeClaimPending** - PVC pending 15m+
- **PersistentVolumeInodesLow** - Inodes >85% used

### Deployment Alerts (`deployment-alerts.yaml`)
- **DeploymentNoAvailableReplicas** - Zero replicas for 5m (critical)
- **DeploymentReplicasMismatch** - Replicas don't match spec for 15m
- **StatefulSetReplicasMismatch** - StatefulSet replicas not ready
- **DaemonSetNotScheduled** - DaemonSet not on all nodes
- **DaemonSetPodsNotReady** - DaemonSet pods not ready
- **HPAAtMaxReplicas** - HPA at max for 30m

### ArgoCD Alerts (`argocd-alerts.yaml`)
- **ArgoCDAppOutOfSync** - App out of sync for 30m
- **ArgoCDAppUnhealthy** - App unhealthy for 15m
- **ArgoCDAppSyncFailed** - Unknown sync status for 5m
- **ArgoCDServerNotReady** - ArgoCD server unavailable
- **ArgoCDRepoServerNotReady** - Repo server unavailable

## Context
During Renovate testing, pods were OOMKilled but no alerts fired because we only had node-level alerts. These new rules provide pod/container-level visibility.

## Test plan
- [ ] Merge and verify ArgoCD syncs the PrometheusRules
- [ ] Check Prometheus UI to confirm rules are loaded
- [ ] Verify alerts appear in Grafana Alerting

🤖 Generated with [Claude Code](https://claude.com/claude-code)