### PR TITLE
fix: add session affinity via service manifest overlay

### DIFF
--- a/apps/pihole/application.yaml
+++ b/apps/pihole/application.yaml
@@ -30,12 +30,8 @@ spec:
               metallb.universe.tf/allow-shared-ip: pihole-dns
           serviceWeb:
             type: ClusterIP
-            # Session affinity ensures exporter requests go to same pod
-            # Required because PiHole API sessions are instance-specific
-            sessionAffinity: ClientIP
-            sessionAffinityConfig:
-              clientIP:
-                timeoutSeconds: 10800  # 3 hours
+            # Note: sessionAffinity configured via manifest overlay
+            # (Helm chart doesn't support sessionAffinity value)
 
           # Web UI ingress for management
           ingress:

--- a/apps/pihole/manifests/pihole-web-service-patch.yaml
+++ b/apps/pihole/manifests/pihole-web-service-patch.yaml
@@ -1,0 +1,32 @@
+---
+# Service patch to add sessionAffinity to pihole-web
+# The Helm chart doesn't support sessionAffinity as a value,
+# so we override the service here.
+# PiHole API sessions are instance-specific, so all requests
+# from the same client must go to the same pod.
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-web
+  namespace: pihole
+  labels:
+    app: pihole
+    app.kubernetes.io/name: pihole
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800  # 3 hours
+  selector:
+    app: pihole
+    release: pihole
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https


### PR DESCRIPTION
## Summary
- Remove ineffective Helm values for sessionAffinity (chart doesn't support it)
- Add service manifest overlay that properly configures sessionAffinity

## Problem
Previous PR added sessionAffinity to Helm values, but the pihole chart doesn't template that field. The service was created without session affinity.

## Solution
Create a service manifest in `apps/pihole/manifests/` that overrides the Helm-generated service with the correct sessionAffinity configuration.

## Test plan
- [ ] Verify ArgoCD syncs the manifest
- [ ] Verify `kubectl get svc pihole-web -n pihole -o jsonpath='{.spec.sessionAffinity}'` returns `ClientIP`
- [ ] Verify pihole-exporter becomes Ready with stable sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)