### PR TITLE
fix: update home-assistant chart to available version

### DIFF
--- a/apps/home-assistant/application.yaml
+++ b/apps/home-assistant/application.yaml
@@ -12,7 +12,7 @@ spec:
     # Home Assistant Helm chart from gabe565
     repoURL: https://charts.gabe565.com
     chart: home-assistant
-    targetRevision: 0.25.1
+    targetRevision: 0.17.0
     helm:
       valuesObject:
         # Image settings


### PR DESCRIPTION
## Summary
- Update home-assistant chart from 0.25.1 to 0.17.0

## Problem
ArgoCD shows "Unknown" sync status because chart version 0.25.1 doesn't exist:
```
chart "home-assistant" version "0.25.1" not found in https://charts.gabe565.com repository
```

## Solution
Update to 0.17.0 which is the latest available version in the gabe565 repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)