### PR TITLE
feat: add book-review-publisher ArgoCD application

### DIFF
--- a/apps/book-review-publisher/application.yaml
+++ b/apps/book-review-publisher/application.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: book-review-publisher
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  sources:
+    - repoURL: https://github.com/Mosher-Labs/homelab-gitops.git
+      targetRevision: main
+      path: apps/book-review-publisher/manifests
+    - repoURL: https://github.com/Mosher-Labs/book-review-publisher.git
+      targetRevision: main
+      path: manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: book-review-publisher
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/apps/book-review-publisher/manifests/namespace.yaml
+++ b/apps/book-review-publisher/manifests/namespace.yaml
@@ -1,0 +1,10 @@
+---
+# The sealed secret for GITHUB_PAT goes in this directory.
+# See the book-review-publisher RUNBOOK.md for creation instructions.
+# Until the sealed secret is added, the Deployment pod will fail to start.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: book-review-publisher
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"

--- a/apps/book-review-publisher/manifests/sealed-secret.yaml
+++ b/apps/book-review-publisher/manifests/sealed-secret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: book-review-publisher-secrets
+  namespace: book-review-publisher
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData:
+    github-pat: AgDDyBLyDySAj9MPf5ACxZ8qvhNPs39eT6x8MQisvOn+jbS3Vea1BDq+jNb86r3taLxhEjlPOlVK/q5MGK9wg+8lfAkRwgcsilUUIgeJOkj3XQmjngYF9igs0nDyROM1P1AW71Y7Szsod4X6zzeiCFpwrvGXfmFz3khTWxvsMDc8jK8euCTjjohIzsB+BXfQBW/l0QVs3mGX0D+o92SIkqCFpNy1vFi0LRpMz8DNg4EHyUkWaptewbwWzcPi+kTheimpk+q1qilhp9aYp80RC3i4SDHaTapQ41CepvYhxwJwh6bNIi/FrLWyOB4Qgf7rZ5xzgUmuhXgNUHYQNBEiBPe2Kz+M7pqR4Zv222wWV14nC7jOEUNeFpI5JVFPQX8ySJYu3aw1azOFHAwxG6lLyE7/RjeKahgbfTXNnSJur5hdwroGl3cGmC/lyD5kdy1tylRvFbqeoB+3BrC4gW/0DzFyazzxxS+WyBW6zFhZOiboYHLOTqGKuoqMw2wUq8TaZDh+ret++8/RxBZgCSXkIxdkOa7sTQbCSikwNxc3twdEgykELqyueZJPBx3XdEIlM8NYrRfguyT876jJLCX9kGwKwtgw1SChuNFSZ6wl938iCf9dG8eJhmBppk8KUx1MxG68lTmCYxFYYnPfd/B0zMcWdxLvCTVjHdL7Mj3LUakLPF1/FKcySvmlRwE2Mt6nFAlOrLIcp0dyZj9uojtvodJWAqVTgnlWrNgkJ4p1ULH4zQJNL3Yh29mtDyOGBxN847bDhWGWH6I1mCWLP774vkfacoXf5lYs8VIIaJ0DDM3IZlD2d00xY0RuzNeHwVM=
+  template:
+    metadata:
+      name: book-review-publisher-secrets
+      namespace: book-review-publisher


### PR DESCRIPTION
## Summary

- Adds ArgoCD Application for the new `book-review-publisher` webhook service
- Multi-source: sealed secret (this repo) + app manifests (book-review-publisher repo)
- Namespace pre-created with sync-wave -2, sealed secret at sync-wave -1

## Test plan

- [x] PR passes pre-commit checks
- [ ] ArgoCD syncs successfully after merge
- [ ] `kubectl get pods -n book-review-publisher` shows pod Running
- [ ] `curl http://book-review-publisher.mosher-labs.local/health` returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)