### PR TITLE
feat: add cloudflared sealed secret for book-review-publisher

### DIFF
--- a/apps/book-review-publisher/manifests/cloudflared-sealed-secret.yaml
+++ b/apps/book-review-publisher/manifests/cloudflared-sealed-secret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflared-credentials
+  namespace: book-review-publisher
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData:
+    tunnel-token: AgAvjRYBi/MV6aI5IbWaULPRMuzG/l8xbGHzIhlWHWiwmij8X3yP3mdkC8ybH1u6A4h0qaRU0xxjDNn8UJctsLXMAi8+VbLHC44nHI2GPvWZiL7QXjVuywOmsCvSCCqpJoVcaGGN5yQz4SDWJo5SdoeI42KRr+ud3xegcSGnJ2n6us4iG1qnIKI1G5Ed4wRCdVamBgzXTbKar96svSziNHbtCWezAsCjyGH8UekUF9woU+X0diTimB5PO7KOKTLMNSz1+tzAMT8pmgWU8Bm/o1lPUbt+O5BO6BJsxs3WhIy1MJ+dlo6YYKBqW8wXmyrDNLpi9FLMA+oisQDx3cxoS8Sb+E0RdOxHN3GiIy45wGkjQkwUA5E4Lh3VThXtL3SC5y0Rjz26f9U2TXYa44i64hYSRdGVeR9FcpDpMiRX241oL88yc5RdbQ9AFBzKrD6oiW/LvOye6+XpaPEmwi1Z/3bUcTE1mU0xeYkXOL1pC7/zTjBOrJUMU21jpujVwqNXrfQosHQhU+HWaGcPpTI8MwtMOEcAvpxYTu5bVBmIw4OJosfO6L+dmmuF03QDSvRKzKgnaE53irBEYtge2oaWuQKABqpMNIEVpDRk4BwjrSSWmo0fNUubFJxT0j9kPfAnI8gZAGchTbvz4H/FxNuoVi3W4utHkV1pXpdEigACu9cqFeAfkzLxVbGF4w9toL/h7CckQ//LzpVBM/FhTStUzfYYvsNn6km7kAmob7jyzQpHmJnw/IKvkytZQ7Rs04vG0/WrLeCiSDtyg/Bgj+iCB9NWT7//EOrnM1Hdt0bZNsUiDdvfAH6vQ/dPER/boy0SBwLOH4n4MVRoOIzmQjNIBUprOZhFzIpr8LVdZERHiltC7Bfl1Bf/thBOcO1jAuKx7YAea/srZo2NWiEq2slRnxNMXA6+QqYX/2+oIBUPStsFzwgR9bUkCccB
+  template:
+    metadata:
+      name: cloudflared-credentials
+      namespace: book-review-publisher
+    type: Opaque


### PR DESCRIPTION
Adds the sealed tunnel token for the cloudflared sidecar in book-review-publisher.

Merge alongside mosher-labs/book-review-publisher#7 which adds the sidecar to the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)