### PR TITLE
feat: add auth token sealed secret for book-review-publisher

### DIFF
--- a/apps/book-review-publisher/manifests/auth-sealed-secret.yaml
+++ b/apps/book-review-publisher/manifests/auth-sealed-secret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: book-review-publisher-auth
+  namespace: book-review-publisher
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData:
+    auth-token: AgAv8WAgNfmheut1ZD4IKP/erZmMaxFAYRaiWqR+41dFyPff9pOAzcMxIOmdIW1LMAAa6MCzoHw1zAtMHIRmEVJbzFXklpSgnHL0UX4obKrci9ao2WfY7+/u+vJSZIQzDHOlaljfATZDfZprZNWrSS6im5BQJnsZ5ygak9YZD81w6vHfr5tlKmsh4wz3Wz4tMue7/USrEHTEHaRniT7VM9Ey80iegKzTYjuFDWFI8u76fViz43xUqrO+/zDgZ/+8/iYIsUobAqZVk3UYOHU+JPE3k8BCDs64uLi/jK7Y+eF6AxTD4IFAvr9hmpTcWCtPOKf29iC1252i+aURuG6wqk3T+59cPEHdkDmmIhjxwP2iOIk8XzBQiyFEVLMmMjW2LGN6BZhhKK1gto9fw89QlCTW4WnwdYvZbHzzNAy54k4xcO3jDBYRhimKB7deJxLrOxVJVrw+XxTguqiLbgnbHX8DV/pWBSJEpOgq++P6RFSIZWzzDmVI9OwJzoEBMhxJWZ09M6+Ntgid5xuAUHUP1Lo5r2hzvNbAoNKysD7eU6w92uSY25bK17Mmnh/QP6kILAT8BoiLOb+iv7C0CBIRcaVluQyoknPUnZm7ZCLYvV/HqkHaxgQcKOFkB/9FYeLqPlyWBwITb/v3MEj0po6DiHSJrPbp1BaUyDmExFje13G7oTBQJC81DrRnPimFiSmbi8+7OrUZfcU9x9LVlsnDaui4YA/4ALh/RI4M0kudHvr7W2uzsxXkJ1WHthNPIZLqjrM49bG4GM1bl9hDjjH26Icf
+  template:
+    metadata:
+      name: book-review-publisher-auth
+      namespace: book-review-publisher
+    type: Opaque

--- a/apps/book-review-publisher/manifests/cloudflared-sealed-secret.yaml
+++ b/apps/book-review-publisher/manifests/cloudflared-sealed-secret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: cloudflared-credentials
+  namespace: book-review-publisher
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  encryptedData:
+    tunnel-token: AgAvjRYBi/MV6aI5IbWaULPRMuzG/l8xbGHzIhlWHWiwmij8X3yP3mdkC8ybH1u6A4h0qaRU0xxjDNn8UJctsLXMAi8+VbLHC44nHI2GPvWZiL7QXjVuywOmsCvSCCqpJoVcaGGN5yQz4SDWJo5SdoeI42KRr+ud3xegcSGnJ2n6us4iG1qnIKI1G5Ed4wRCdVamBgzXTbKar96svSziNHbtCWezAsCjyGH8UekUF9woU+X0diTimB5PO7KOKTLMNSz1+tzAMT8pmgWU8Bm/o1lPUbt+O5BO6BJsxs3WhIy1MJ+dlo6YYKBqW8wXmyrDNLpi9FLMA+oisQDx3cxoS8Sb+E0RdOxHN3GiIy45wGkjQkwUA5E4Lh3VThXtL3SC5y0Rjz26f9U2TXYa44i64hYSRdGVeR9FcpDpMiRX241oL88yc5RdbQ9AFBzKrD6oiW/LvOye6+XpaPEmwi1Z/3bUcTE1mU0xeYkXOL1pC7/zTjBOrJUMU21jpujVwqNXrfQosHQhU+HWaGcPpTI8MwtMOEcAvpxYTu5bVBmIw4OJosfO6L+dmmuF03QDSvRKzKgnaE53irBEYtge2oaWuQKABqpMNIEVpDRk4BwjrSSWmo0fNUubFJxT0j9kPfAnI8gZAGchTbvz4H/FxNuoVi3W4utHkV1pXpdEigACu9cqFeAfkzLxVbGF4w9toL/h7CckQ//LzpVBM/FhTStUzfYYvsNn6km7kAmob7jyzQpHmJnw/IKvkytZQ7Rs04vG0/WrLeCiSDtyg/Bgj+iCB9NWT7//EOrnM1Hdt0bZNsUiDdvfAH6vQ/dPER/boy0SBwLOH4n4MVRoOIzmQjNIBUprOZhFzIpr8LVdZERHiltC7Bfl1Bf/thBOcO1jAuKx7YAea/srZo2NWiEq2slRnxNMXA6+QqYX/2+oIBUPStsFzwgR9bUkCccB
+  template:
+    metadata:
+      name: cloudflared-credentials
+      namespace: book-review-publisher
+    type: Opaque


### PR DESCRIPTION
Adds sealed secret for `book-review-publisher-auth` containing the bearer token for `POST /publish`.

Merge alongside mosher-labs/book-review-publisher#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)