### PR TITLE
fix: filter renovate autodiscovery by renovate topic

### DIFF
--- a/infrastructure/renovate/manifests/cronjob-benniemosher-dev.yaml
+++ b/infrastructure/renovate/manifests/cronjob-benniemosher-dev.yaml
@@ -73,6 +73,8 @@ spec:
                 # Org-specific autodiscover filter
                 - name: RENOVATE_AUTODISCOVER_FILTER
                   value: "benniemosher-dev/*"
+                - name: RENOVATE_AUTODISCOVER_TOPICS
+                  value: "renovate"
               volumeMounts:
                 - name: config
                   mountPath: /config

--- a/infrastructure/renovate/manifests/cronjob-benniemosher.yaml
+++ b/infrastructure/renovate/manifests/cronjob-benniemosher.yaml
@@ -74,6 +74,8 @@ spec:
                 # User-specific autodiscover filter
                 - name: RENOVATE_AUTODISCOVER_FILTER
                   value: "benniemosher/*"
+                - name: RENOVATE_AUTODISCOVER_TOPICS
+                  value: "renovate"
               volumeMounts:
                 - name: config
                   mountPath: /config


### PR DESCRIPTION
## Summary

- Adds `RENOVATE_AUTODISCOVER_TOPICS: renovate` to both `cronjob-benniemosher` and `cronjob-benniemosher-dev`
- Renovate was scanning all 26 `benniemosher/*` repos and OOMKilling at the 2Gi limit around repo 10
- Added the `renovate` topic to the 4 repos that actually have a `renovate.json`: `moniquemosher.com`, `benniemosher.com`, `dotfiles`, `recordings-archiver`

## Test plan

- [ ] After merge and ArgoCD sync, manually trigger the CronJob and verify it completes without OOMKill
- [ ] Verify only the 4 tagged repos are processed

🤖 Generated with [Claude Code](https://claude.com/claude-code)