### PR TITLE
fix: pin grafana PVC storageClassName to local-path

### DIFF
--- a/infrastructure/kube-prometheus-stack/application.yaml
+++ b/infrastructure/kube-prometheus-stack/application.yaml
@@ -84,6 +84,7 @@ spec:
             persistence:
               enabled: true
               size: 5Gi
+              storageClassName: local-path
             # Grafana configuration
             grafana.ini:
               server:


### PR DESCRIPTION
## Summary

- Grafana PVC was created with `storageClassName: local-path` (k3s default)
- New `valuesObject` config didn't specify it, causing ArgoCD to see a diff
  against `nil` and fail with an immutable PVC spec error
- Pinning `storageClassName: local-path` makes the desired state match reality

## Test plan

- [ ] `kube-prometheus-stack` application shows Healthy + Synced after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)