### PR TITLE
fix: update sealed-secrets helm repo URL and bump to 2.19.1

### DIFF
--- a/infrastructure/sealed-secrets/application.yaml
+++ b/infrastructure/sealed-secrets/application.yaml
@@ -16,10 +16,10 @@ spec:
   # SOURCE: Where is the Helm chart?
   source:
     # Sealed Secrets official Helm repo
-    repoURL: https://bitnami-labs.github.io/sealed-secrets
+    repoURL: https://bitnami.github.io/sealed-secrets
     # Which chart to use
     chart: sealed-secrets
-    targetRevision: 2.18.6
+    targetRevision: 2.19.1
     # Helm values
     helm:
       values: |


### PR DESCRIPTION
## Summary

- `https://bitnami-labs.github.io/sealed-secrets` returns 404 — the repo moved
- New URL: `https://bitnami.github.io/sealed-secrets`
- Also bumps chart from `2.18.6` → `2.19.1` (latest)

## Test plan

- [ ] `sealed-secrets` application shows Healthy + Synced after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)